### PR TITLE
Using WPA2 for hostapd (read more below)

### DIFF
--- a/doc/install_en.md
+++ b/doc/install_en.md
@@ -96,3 +96,13 @@ reboot
 PiRogue has a tiny OLED screen on top of it. This screen displays two different screens:
 *  the boot screen defined in `oled-screen/boot.py`
 *  the details screen defined in `oled-screen/infos.py`
+
+## 7 - A little note about hostapd and WPA2
+
+We use hostapd to create a new Wifi Access Point. This access point is protected using WPA2.
+
+**some Wifi dongle does not support WPA2 when acting as an access point**. If you cannot connect to the PiRogue access point with the correct passphrase your Wifi dongle may not be supported.
+
+We have successfully tested with:
+
+* TP-Link WN722N v1

--- a/doc/install_en.md
+++ b/doc/install_en.md
@@ -106,3 +106,18 @@ We use hostapd to create a new Wifi Access Point. This access point is protected
 We have successfully tested with:
 
 * TP-Link WN722N v1
+
+If you want to have an open access point, edit file */usr/share/PiRogue/hostapd/hostapd.conf* and change its content with:
+
+```
+driver=nl80211
+ssid=PiRogue
+channel=6
+auth_algs=3
+```
+
+Then, restart hostapd service:
+
+```bash
+sudo systemctl restart hostapd
+```

--- a/doc/install_fr.md
+++ b/doc/install_fr.md
@@ -97,3 +97,13 @@ reboot
 Il est possible de modifier les informations affichées sur l'écran en éditant les fichiers suivants : 
 *  l'écran de démarrage : `oled-screen/boot.py`
 *  l'écran affichant les informations de connexion : `oled-screen/infos.py`
+
+## 7 - Un petit mot sur hostapd et le WPA2
+
+Nous utilisons hostapd pour créer un point d'accès Wifi. WPA2 est utilisé pour protéger l'accès à ce point d'accès.
+
+**certaines clés Wifi (dongle) ne supportent pas WPA2 en mode point d'accès**. Si vous n'arrivez pas à vous connecter à votre point d'accès PiRogue avec le bon mot de passe, votre clé Wifi n'est peut être pas supportée.
+
+Nous avons testé le matériel suivant avec succès :
+
+* TP-Link WN722N v1

--- a/doc/install_fr.md
+++ b/doc/install_fr.md
@@ -107,3 +107,19 @@ Nous utilisons hostapd pour créer un point d'accès Wifi. WPA2 est utilisé pou
 Nous avons testé le matériel suivant avec succès :
 
 * TP-Link WN722N v1
+
+Si vous préférez un point d'accès ouvert, éditez le fichier */usr/share/PiRogue/hostapd/hostapd.conf* et changez son contenu pour le suivant :
+
+```
+driver=nl80211
+ssid=PiRogue
+channel=6
+auth_algs=3
+```
+
+Puis, redémarrez hostapd :
+
+```bash
+sudo systemctl restart hostapd
+```
+

--- a/hostapd/hostapd.conf
+++ b/hostapd/hostapd.conf
@@ -3,4 +3,11 @@ country_code=FR
 driver=nl80211
 ssid=PiRogue
 channel=6
-auth_algs=3
+auth_algs=1           # 1=wpa, 2=wep, 3=both
+wpa=2                 # WPA2 only
+wpa_key_mgmt=WPA-PSK
+rsn_pairwise=CCMP
+
+# Uncomment (remove '#') on line below and change the value of your wifi password for something other than 'superlongkey'
+#wpa_passphrase=superlongkey
+


### PR DESCRIPTION
WPA2 is useful to prevent other device than the one being analysed to connect to the access point.

All USB dongles does not support AP mode with WPA2 ; we have successfully tested with a
TP-Link TL-WN722N v1